### PR TITLE
Remove flash of unstyled content while loading the page.

### DIFF
--- a/src/style/_base.scss
+++ b/src/style/_base.scss
@@ -1,3 +1,7 @@
 .cursor-pointer {
   cursor: pointer;
 }
+
+html {
+  visibility: visible;
+}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -5,7 +5,11 @@
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, shrink-to-fit=no, user-scalable=no">
-
+  <style>
+    html {
+      visibility: hidden;
+    }
+  </style>
   <title>
     <%= htmlWebpackPlugin.options.title || 'Application name'%>
   </title>
@@ -66,7 +70,7 @@
                 </div>
               <button
                 class="list-group-item list-group-item-action cursor-pointer d-flex justify-content-between align-items-center"
-                v-size-price=15 
+                v-size-price=15
                 id="big"
               >
                Big


### PR DESCRIPTION
You could see the unstyled content while loading the page. It is fixed by toggling the `visibility` css property of a <html> element - setting it to hidden in the header and then again to visible in _base.scss. This way the <html> becomes visible only after the page is loaded.